### PR TITLE
Removed libpng as Raid already has png support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,9 +13,6 @@
 [submodule "lib/sys/curl"]
 	path = lib/sys/curl
 	url = https://github.com/curl/curl.git
-[submodule "lib/sys/libpng"]
-	path = lib/sys/libpng
-	url = https://github.com/glennrp/libpng.git
 [submodule "lib/luajit"]
 	path = lib/luajit
 	url = https://github.com/LeonTheo02/LuaJIT.git


### PR DESCRIPTION
Libpng was for Payday 2 Linux version and PNG support already exists in Raid